### PR TITLE
(v39) Fix ES games browsing hanging and system crashing

### DIFF
--- a/board/batocera/allwinner/h3/cha/boot/extlinux.conf
+++ b/board/batocera/allwinner/h3/cha/boot/extlinux.conf
@@ -1,4 +1,4 @@
 LABEL batocera.linux
   LINUX /boot/linux
   FDT /boot/capcom-home-arcade.dtb
-  APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200 console=tty3 vt.global_cursor_default=0 video=HDMI-A-1:1280x720@60
+  APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200 console=tty3 vt.global_cursor_default=0 video=HDMI-A-1:1280x720@60 cma=128MB


### PR DESCRIPTION
When browsing games, worse if moving fast, Emulation Station freezes for long periods and then the whole system will stop responding/crash.